### PR TITLE
fix: disable sdist publishing until we fix it

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,6 +100,10 @@ jobs:
           name: build
           path: dist
 
+      - name: Remove all non wheel files
+        run: |
+          find dist -type f -not -name "*.whl" -delete
+
       - name: Publish package distributions to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pantos-client-library"
-version = "3.1.2"
+version = "3.1.3"
 description = "Client library for engaging with the Pantos system"
 authors = ["Pantos GmbH <contact@pantos.io>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Test(s)
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Disables sdist and upgrades to 3.1.3.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions

_Please replace this line with instructions on how to test your changes._


## [optional] Are there any post deployment tasks we need to perform?